### PR TITLE
fixed linkedin refs

### DIFF
--- a/_members/gabriel-pugina.md
+++ b/_members/gabriel-pugina.md
@@ -11,7 +11,7 @@ links:
   # orcid:
   github: gabreilpugina
   # google-scholar: 
-  linkedin: https://www.linkedin.com/in/bo-meyering-37955b139/
+  linkedin: gabriel-pugina-955987161/
   # research-gate: https://www.researchgate.net/profile/Gabriel-Pugina
   # uf-directory:
 ---


### PR DESCRIPTION
This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
