### PR TITLE
changed hyperlink for personal site

### DIFF
--- a/_members/bo-meyering.md
+++ b/_members/bo-meyering.md
@@ -7,7 +7,7 @@ aliases:
   - Bryce Meyering
 links:
   email: bbmeyering@ufl.edu
-  home-page: bomeyering.me
+  home-page: https://www.bomeyering.me
   orcid: 0000-0002-1524-787X
   github: BoMeyering
   google-scholar: 60-Xe30AAAAJ


### PR DESCRIPTION
This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
